### PR TITLE
Updated the config for installing nightly build

### DIFF
--- a/ansible/machine_config.yml
+++ b/ansible/machine_config.yml
@@ -51,7 +51,7 @@
       yum_repository:
         name: "gluster-nightly-master"
         description: "Gluster Nightly builds (master branch)"
-        baseurl: "http://artifacts.ci.centos.org/gluster/nightly/master/$releasever/$basearch"
+        baseurl: "http://artifacts.ci.centos.org/gluster/nightly/devel/$releasever/$basearch"
         gpgcheck: false
         repo_gpgcheck: false
         keepalive: yes


### PR DESCRIPTION
Due to change in the naming convention of the gluster branch
the nightly build needs to be installed from devel instead of
master.

fixes: #3

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>