### PR TITLE
Installing glusterfs-geo-replication

### DIFF
--- a/ansible/machine_config.yml
+++ b/ansible/machine_config.yml
@@ -60,7 +60,7 @@
   tasks:
     - name: Install Gluster and additional packages on servers
       yum:
-        name: ['python3', 'policycoreutils-python', 'glusterfs-server', 'glusterfs-fuse', 'glusterfs-api', 'arequal']
+        name: ['python3', 'policycoreutils-python', 'glusterfs-server', 'glusterfs-fuse', 'glusterfs-api', 'arequal', 'glusterfs-geo-replication']
         state: present
       retries: 10
       delay: 5


### PR DESCRIPTION
Fixes upgrade failure caused due to dependency on
geo-replication

fixes: #5

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>